### PR TITLE
Fix improper coloring

### DIFF
--- a/one-dark.json
+++ b/one-dark.json
@@ -601,7 +601,7 @@
       "showEmptyIntervals": false
     },
     "identifier": {
-      "fgColor": "Gray 120",
+      "fgColor": "Red 70",
       "layer": 10,
       "fullLine": false,
       "showEmptyIntervals": false

--- a/one-dark.json
+++ b/one-dark.json
@@ -486,6 +486,18 @@
         "style": "BORDER"
       }
     },
+    "editor.indent.guide": {
+      "fgColor": "Gray 70",
+      "decoration": {
+        "style": "SOLID"
+      }
+    },
+    "editor.indent.guide.current": {
+      "fgColor": "Gray 100",
+      "decoration": {
+        "style": "SOLID"
+      }
+    },
     "comment": {
       "fgColor": "Gray 90",
       "layer": 5,


### PR DESCRIPTION
A few things I noticed working in php and JavaScript is that there were a few colors that didn't quite match up with the theme in vs code. 

fleet snippet:

![image](https://github.com/DevBlooming/jetbrains-fleet-one-dark-theme/assets/45863534/c59d9d9a-6eb6-49e9-9e8a-b2b281b997e4)

vscode snippet:

![image](https://github.com/DevBlooming/jetbrains-fleet-one-dark-theme/assets/45863534/e404fdb1-e24c-48af-b3c9-9545a30521f4)


Starting off there is a blue line to denote the indent guide; It seems that this is a default color in fleet. I wanted to match it to the same colors in vscode or as close as possible so I switched that color to gray to prevent the default from creeping in.

I also noticed that the variable colors didn't match like I would expect. It seems as though variables are red in vscode but gray in fleet. I changed the identifier color to match the color in vscode.

fleet snippet after changes (seperated the if statement because fleet considers the else part of the same block):

![image](https://github.com/DevBlooming/jetbrains-fleet-one-dark-theme/assets/45863534/c03b9d63-041d-461c-9025-5417c66f29b4)

After the changes are made you can see the indent guides match what vscode does and that the variable colors are also the same.